### PR TITLE
fix #7

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'numtel:mysql-server',
-  version: '1.0.1',
+  version: '1.0.2',
   summary: 'Run MySQL server inside your Meteor app',
   git: 'https://github.com/numtel/meteor-mysql-server',
   documentation: 'README.md'

--- a/plugin/mysqlServer.js
+++ b/plugin/mysqlServer.js
@@ -168,7 +168,7 @@ Plugin.registerSourceHandler('mysql.json', {
             if(error) return fut['throw'](error);
             console.log('[MySQL] Performing initialization queries...  ');
             db.query(initQueries, MBE(function(error, rows) {
-              if(error) return fut['throw'](error);
+              if(error) return fut['throw'](new Error(error.message));
               db.destroy(); // Close connection
               return fut['return']();
             }));


### PR DESCRIPTION
fixed #7.

By this way node will throw a meaningful error like this:

```
[[[[[ ~/git/meteor/mysql-test ]]]]]

=> Started proxy.
=> Started MySQL.
[MySQL] Performing initialization queries...
=> Errors prevented startup:

   While building the application:
   packages/mysqlServer/plugin/mysqlServer.js:171:1: ER_PARSE_ERROR: You have an error in your SQL syntax; check the
   manual that corresponds to your MySQL server version for the right syntax to use near 'REATE DATABASE chicks;
   USE chicks;

   CREATE TABLE `sexies` (
   `name` varchar(45)' at line 1 (compiling app.mysql.json)
   at Query.<anonymous> (packages/mysqlServer/plugin/mysqlServer.js:171:1)
   at runWithEnvironment (/tools/utils/fiber-helpers.js:112:21)
```

I don't know much about the meteor internal so I might miss something, but at least the error message can be shown normally now.
